### PR TITLE
Put temporary shims in $HOME, not $TMP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - '0.8'
+  - '0.10'
+  - '0.12'
+  - 'iojs'
+before_install:
+  - npm install -g npm@latest

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var path = require('path')
 var signalExit = require('signal-exit')
+var homedir = require('os-homedir')() + '/.node-spawn-wrap-'
 
 var shim = '#!' + process.execPath + '\n' +
   fs.readFileSync(__dirname + '/shim.js')
@@ -201,7 +202,7 @@ function setup (argv, env) {
     root: process.pid
   }, null, 2) + '\n'
 
-  var workingDir = '/tmp/node-spawn-wrap-' + process.pid + '-' +
+  var workingDir = homedir + process.pid + '-' +
     crypto.randomBytes(6).toString('hex')
 
   signalExit(function () {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "foreground-child": "^1.2.0",
     "mkdirp": "^0.5.0",
+    "os-homedir": "^1.0.1",
     "rimraf": "^2.3.3",
     "signal-exit": "^2.0.0"
   },


### PR DESCRIPTION
The /tmp mount is sometimes mounted as noexec, especially on systems
where tmp is world-writable.

Even though these shims ARE extremely temporary (they are deleted at the
end of the process), it makes more sense to put them in $HOME rather
than /tmp.

Closes #3

Thanks @rvagg and @bcoe for the spot.