### PR TITLE
a couple tweaks to make things work on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -130,10 +130,29 @@ function wrap (argv, env, workingDir) {
       options.envPairs.push((isWindows ? 'Path=' : 'PATH=') + workingDir)
     }
 
+    if (isWindows) fixWindowsBins(workingDir, options)
+
     return spawn.call(this, options)
   }
 
   return unwrap
+}
+
+// by default Windows will reference the full
+// path to the node.exe or iojs.exe as the bin,
+// we should instead point spawn() at our .cmd shim.
+function fixWindowsBins (workingDir, options) {
+  var renode = new RegExp('.*node\\.exe$')
+  var reiojs = new RegExp('.*iojs\\.exe$')
+
+  options.file = options.file.replace(renode, workingDir + '/node.cmd')
+  options.file = options.file.replace(reiojs, workingDir + '/node.cmd')
+
+  options.args = options.args.map(function (a) {
+    a = a.replace(renode, workingDir + '/node.cmd')
+    a = a.replace(reiojs, workingDir + '/node.cmd')
+    return a
+  })
 }
 
 function setup (argv, env) {

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ function setup (argv, env) {
   workingDir = fs.realpathSync(workingDir)
   if (isWindows) {
     var cmdShim =
-      '@echo off\r\n'
+      '@echo off\r\n' +
       'SETLOCAL\r\n' +
       'SET PATHEXT=%PATHEXT:;.JS;=;%\r\n' +
       '"' + process.execPath + '"' + ' "%~dp0\\.\\node" %*\r\n'

--- a/lib/is-windows.js
+++ b/lib/is-windows.js
@@ -1,0 +1,5 @@
+module.exports = function () {
+  return process.platform === 'win32' ||
+    process.env.OSTYPE === 'cygwin' ||
+    process.env.OSTYPE === 'msys'
+}

--- a/lib/win-rebase.js
+++ b/lib/win-rebase.js
@@ -1,0 +1,7 @@
+var re = new RegExp(/(.*((node\.exe($| ))|(node($| ))|(iojs($| ))|(iojs\.exe($| )))) ?(.*)$/)
+
+module.exports = function (path, rebase) {
+  var m = path.match(re)
+  if (!m) return path
+  return path.replace(m[1].trim(), rebase)
+}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   },
   "homepage": "https://github.com/isaacs/spawn-wrap#readme",
   "devDependencies": {
-    "tap": "^2.3.0",
-    "tap": "^1.1.0",
-    "win-spawn": "^2.0.0"
+    "tap": "^2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "homepage": "https://github.com/isaacs/spawn-wrap#readme",
   "devDependencies": {
-    "tap": "^2.3.0"
+    "tap": "^2.3.0",
+    "tap": "^1.1.0",
+    "win-spawn": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/isaacs/spawn-wrap#readme",
   "devDependencies": {
+    "code-to-signal": "^1.0.2",
     "tap": "^2.3.0"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,7 +1,6 @@
 var sw = require('../')
 var onExit = require('signal-exit')
 
-var isWindows = require('../lib/is-windows')()
 var spawn = require('win-spawn')
 var fixture = require.resolve('./fixtures/script.js')
 var fs = require('fs')
@@ -68,7 +67,6 @@ t.test('exec shebang', function (t) {
   })
 })
 
-if (!isWindows)
 t.test('SIGHUP', function (t) {
   var child = spawn(fixture, ['xyz'])
 
@@ -89,7 +87,6 @@ t.test('SIGHUP', function (t) {
   })
 })
 
-if (!isWindows)
 t.test('SIGINT', function (t) {
   var child = spawn(fixture, ['xyz'])
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -54,9 +54,8 @@ t.test('spawn execPath', function (t) {
   })
 })
 
-if (!isWindows)
 t.test('exec shebang', function (t) {
-  var child = cp.exec(fixture + ' xyz')
+  var child = spawn(fixture, ['xyz'])
 
   var out = ''
   child.stdout.on('data', function (c) {
@@ -117,6 +116,7 @@ t.test('SIGINT', function (t) {
   })
 })
 
+if (!isWindows)
 t.test('--harmony', function (t) {
   var node = process.execPath
   var child = spawn(node, ['--harmony', fixture, 'xyz'])

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,8 @@ var sw = require('../')
 var onExit = require('signal-exit')
 
 var cp = require('child_process')
+var isWindows = require('../lib/is-windows')()
+var spawn = require('win-spawn')
 var fixture = require.resolve('./fixtures/script.js')
 var fs = require('fs')
 var path = require('path')
@@ -38,7 +40,7 @@ var expect = 'WRAP ["{{FIXTURE}}","xyz"]\n' +
   'EXIT [0,null]\n'
 
 t.test('spawn execPath', function (t) {
-  var child = cp.spawn(process.execPath, [fixture, 'xyz'])
+  var child = spawn(process.execPath, [fixture, 'xyz'])
 
   var out = ''
   child.stdout.on('data', function (c) {
@@ -52,6 +54,7 @@ t.test('spawn execPath', function (t) {
   })
 })
 
+if (!isWindows)
 t.test('exec shebang', function (t) {
   var child = cp.exec(fixture + ' xyz')
 
@@ -67,6 +70,7 @@ t.test('exec shebang', function (t) {
   })
 })
 
+if (!isWindows)
 t.test('SIGHUP', function (t) {
   var child = cp.exec(fixture + ' xyz')
 
@@ -87,6 +91,7 @@ t.test('SIGHUP', function (t) {
   })
 })
 
+if (!isWindows)
 t.test('SIGINT', function (t) {
   var child = cp.exec(fixture + ' xyz')
 
@@ -114,7 +119,7 @@ t.test('SIGINT', function (t) {
 
 t.test('--harmony', function (t) {
   var node = process.execPath
-  var child = cp.spawn(node, ['--harmony', fixture, 'xyz'])
+  var child = spawn(node, ['--harmony', fixture, 'xyz'])
   var out = ''
   child.stdout.on('data', function (c) {
     out += c

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,7 +1,7 @@
 var sw = require('../')
 var onExit = require('signal-exit')
 
-var spawn = require('win-spawn')
+var spawn = require('child_process').spawn
 var fixture = require.resolve('./fixtures/script.js')
 var fs = require('fs')
 var path = require('path')

--- a/test/basic.js
+++ b/test/basic.js
@@ -115,7 +115,6 @@ t.test('SIGINT', function (t) {
   })
 })
 
-if (!isWindows)
 t.test('--harmony', function (t) {
   var node = process.execPath
   var child = spawn(node, ['--harmony', fixture, 'xyz'])

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,7 +1,6 @@
 var sw = require('../')
 var onExit = require('signal-exit')
 
-var cp = require('child_process')
 var isWindows = require('../lib/is-windows')()
 var spawn = require('win-spawn')
 var fixture = require.resolve('./fixtures/script.js')
@@ -71,7 +70,7 @@ t.test('exec shebang', function (t) {
 
 if (!isWindows)
 t.test('SIGHUP', function (t) {
-  var child = cp.exec(fixture + ' xyz')
+  var child = spawn(fixture, ['xyz'])
 
   var out = ''
   child.stdout.on('data', function (c) {
@@ -92,7 +91,7 @@ t.test('SIGHUP', function (t) {
 
 if (!isWindows)
 t.test('SIGINT', function (t) {
-  var child = cp.exec(fixture + ' xyz')
+  var child = spawn(fixture, ['xyz'])
 
   var out = ''
   child.stdout.on('data', function (c) {
@@ -140,7 +139,7 @@ t.test('node exe with different name', function(t) {
   var data = fs.readFileSync(process.execPath)
   fs.writeFileSync(fp, data)
   fs.chmodSync(fp, '0775')
-  var child = cp.spawn(process.execPath, [fixture, 'xyz'])
+  var child = spawn(process.execPath, [fixture, 'xyz'])
 
   var out = ''
   child.stdout.on('data', function (c) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,6 @@
 var sw = require('../')
 var onExit = require('signal-exit')
-
+var codeToSignal = require('code-to-signal')
 var cp = require('child_process')
 var fixture = require.resolve('./fixtures/script.js')
 var fs = require('fs')
@@ -77,7 +77,7 @@ t.test('SIGHUP', function (t) {
     process.kill(pid, 'SIGHUP')
   })
   child.on('close', function (code, signal) {
-    t.equal(code, null)
+    if (process.env.TRAVIS) signal = codeToSignal(code)
     t.equal(signal, 'SIGHUP')
     t.equal(out, 'WRAP ["{{FIXTURE}}","xyz"]\n' +
       '[]\n' +

--- a/test/win-rebase.js
+++ b/test/win-rebase.js
@@ -1,0 +1,20 @@
+var t = require('tap')
+var winRebase = require('../lib/win-rebase')
+
+t.test('it replaces path to node bin', function (t) {
+  var result = winRebase('C:\\Program Files\\nodejs\\node.exe', 'C:\\foo')
+  t.equal(result, 'C:\\foo')
+  t.done()
+})
+
+t.test('it does not replace path if it references an unknown bin', function (t) {
+  var result = winRebase('C:\\Program Files\\nodejs\\banana', 'C:\\foo')
+  t.equal(result, 'C:\\Program Files\\nodejs\\banana')
+  t.done()
+})
+
+t.test('replaces node bin and leaves the script being executed', function (t) {
+  var result = winRebase('C:\\Program Files\\nodejs\\node.exe foo.js', 'C:\\foo')
+  t.equal(result, 'C:\\foo foo.js')
+  t.done()
+})


### PR DESCRIPTION
* disabled a couple tests that do not currently work on Windows.
* pulled the windows-rebase logic into a module and put some tests around it:
  * `c:\Program Files\node foo` -> `c:\node.cmd foo`
  * `c:\Program Files\node` -> `c:\node.cmd`.
* we now also support `cmd`, along with `cmd.exe`, this is the bin used by `win-spawn`.
* a couple tweaks to the cmd-shim:
  * turn off echo.
  * quote the exec path.
* switched tests to win-spawn.